### PR TITLE
DRF API view replacing the rpc4django /rpc endpoint for the drawing app

### DIFF
--- a/drawing/api.py
+++ b/drawing/api.py
@@ -26,6 +26,7 @@ class DrawingDeleteView(APIView):
 
         drawing_obj = get_feature_by_uid(uid)
         viewable, _response = drawing_obj.is_viewable(request.user)
-        if viewable:
-            drawing_obj.delete()
+        if not viewable:
+            return _response
+        drawing_obj.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/drawing/api.py
+++ b/drawing/api.py
@@ -1,0 +1,31 @@
+"""DRF API view replacing the rpc4django /rpc endpoint for the drawing app.
+
+Replaces this former XML-RPC method:
+    delete_drawing
+"""
+from __future__ import annotations
+
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+
+class DrawingDeleteView(APIView):
+    """DELETE /api/drawings/<uid>/
+
+    Deletes a drawing (AOI or WindEnergySite) identified by its feature uid,
+    provided the requesting user has view permission on it.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def delete(self, request: Request, uid: str) -> Response:
+        from features.registry import get_feature_by_uid
+
+        drawing_obj = get_feature_by_uid(uid)
+        viewable, _response = drawing_obj.is_viewable(request.user)
+        if viewable:
+            drawing_obj.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/drawing/api.py
+++ b/drawing/api.py
@@ -5,6 +5,8 @@ Replaces this former XML-RPC method:
 """
 from __future__ import annotations
 
+from django.core.exceptions import ObjectDoesNotExist
+from django.http import Http404
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -24,7 +26,10 @@ class DrawingDeleteView(APIView):
     def delete(self, request: Request, uid: str) -> Response:
         from features.registry import get_feature_by_uid
 
-        drawing_obj = get_feature_by_uid(uid)
+        try:
+            drawing_obj = get_feature_by_uid(uid)
+        except ObjectDoesNotExist as exc:
+            raise Http404("Drawing not found") from exc
         viewable, _response = drawing_obj.is_viewable(request.user)
         if not viewable:
             return _response

--- a/drawing/urls.py
+++ b/drawing/urls.py
@@ -1,5 +1,6 @@
 from django.urls import re_path
 from .views import *
+from .api import DrawingDeleteView
 
 urlpatterns = [
     #'',
@@ -8,4 +9,9 @@ urlpatterns = [
     #feature reports
     re_path(r'^wind_report/(\d+)', wind_analysis, name='wind_analysis'), #user requested wind energy site analysis
     re_path(r'^aoi_report/(\d+)', aoi_analysis, name='aoi_analysis'), #user requested area of interest analysis
+]
+
+# DRF API patterns — mounted at /api/ by the project urls.py
+api_urlpatterns = [
+    re_path(r'^drawings/(?P<uid>\w+)/$', DrawingDeleteView.as_view()),
 ]


### PR DESCRIPTION
DRF API view replacing the rpc4django /rpc endpoint for the drawing app.

Replaces this former XML-RPC method:
    delete_drawing

Adds API endpoint for deleting drawings